### PR TITLE
Deleted phone and address from registration request

### DIFF
--- a/app/Http/Requests/Auth/RegisterRequest.php
+++ b/app/Http/Requests/Auth/RegisterRequest.php
@@ -26,9 +26,7 @@ class RegisterRequest extends FormRequest
         return [
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
-            'phone' => ['required', 'numeric', 'digits:9'],
             'password' => ['required', 'confirmed'],
-            'data' => ['required', 'string']
         ];
     }
 


### PR DESCRIPTION
It was needed for the better UX, since now the registration form won't look like the one on some bank website.